### PR TITLE
Automated Changelog Entry for 0.1.0a0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,18 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.0a0
+
+([Full Changelog](https://github.com/ihuicatl/jupyterlab-urdf/compare/3f5977ccd1cbfe59df27b9dc34f5e654da0d1ca9...5ce469cf2ae263c3be22c653150db22d2a5c19b5))
+
+### Enhancements made
+
+- Amphion [#2](https://github.com/ihuicatl/jupyterlab-urdf/pull/2) ([@hbcarlos](https://github.com/hbcarlos))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/ihuicatl/jupyterlab-urdf/graphs/contributors?from=2022-06-10&to=2022-07-06&type=c))
+
+[@hbcarlos](https://github.com/search?q=repo%3Aihuicatl%2Fjupyterlab-urdf+involves%3Ahbcarlos+updated%3A2022-06-10..2022-07-06&type=Issues)
+
 <!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.1.0a0 on main
```
Python version: 0.1.0a0
npm version: jupyterlab_urdf: 0.1.0-alpha.0
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | ihuicatl/jupyterlab-urdf  |
| Branch  | main  |
| Version Spec | 0.1.0-alpha.0 |
