### PR TITLE
Automated Changelog Entry for 0.1.1 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.1
+
+([Full Changelog](https://github.com/ihuicatl/jupyterlab-urdf/compare/v0.1.0a0...780dbc0d67539230876d15c3bf1fd9d4dc7e264a))
+
+### Enhancements made
+
+- Configure JupyterLite [#6](https://github.com/ihuicatl/jupyterlab-urdf/pull/6) ([@ihuicatl](https://github.com/ihuicatl))
+
+### Bugs fixed
+
+- Reload robot once error in XML file is cleared [#14](https://github.com/ihuicatl/jupyterlab-urdf/pull/14) ([@ihuicatl](https://github.com/ihuicatl))
+
+### Documentation improvements
+
+- Update README to include JupyterLite [#13](https://github.com/ihuicatl/jupyterlab-urdf/pull/13) ([@ihuicatl](https://github.com/ihuicatl))
+- Configure JupyterLite [#6](https://github.com/ihuicatl/jupyterlab-urdf/pull/6) ([@ihuicatl](https://github.com/ihuicatl))
+- Update installation instructions [#5](https://github.com/ihuicatl/jupyterlab-urdf/pull/5) ([@ihuicatl](https://github.com/ihuicatl))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/ihuicatl/jupyterlab-urdf/graphs/contributors?from=2022-07-06&to=2022-07-20&type=c))
+
+[@github-actions](https://github.com/search?q=repo%3Aihuicatl%2Fjupyterlab-urdf+involves%3Agithub-actions+updated%3A2022-07-06..2022-07-20&type=Issues) | [@ihuicatl](https://github.com/search?q=repo%3Aihuicatl%2Fjupyterlab-urdf+involves%3Aihuicatl+updated%3A2022-07-06..2022-07-20&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.0a0
 
 ([Full Changelog](https://github.com/ihuicatl/jupyterlab-urdf/compare/3f5977ccd1cbfe59df27b9dc34f5e654da0d1ca9...5ce469cf2ae263c3be22c653150db22d2a5c19b5))
@@ -15,5 +41,3 @@
 ([GitHub contributors page for this release](https://github.com/ihuicatl/jupyterlab-urdf/graphs/contributors?from=2022-06-10&to=2022-07-06&type=c))
 
 [@hbcarlos](https://github.com/search?q=repo%3Aihuicatl%2Fjupyterlab-urdf+involves%3Ahbcarlos+updated%3A2022-06-10..2022-07-06&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.1.1 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | ihuicatl/jupyterlab-urdf  |
| Branch  | main  |
| Version Spec | 0.1.1 |
| Since | v0.1.0a0 |