### PR TITLE
Add documentation dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ By default, the `jlpm build` command generates the source maps for this extensio
 jupyter lab build --minimize=False
 ```
 
+### Development install for documentation
+
+```bash
+pip install -e ".[docs]"
+```
+
 ### Development uninstall
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,22 @@ docs = [
     "sphinx",
     "sphinx-rtd-theme"
 ]
+
+[tool.tbump]
+field = [
+    { name = "channel", default = "" },
+    { name = "release", default = "" },
+]
+file = [
+    { src = "pyproject.toml", version_template = "version = \"{major}.{minor}.{patch}{channel}{release}\"" },
+    { src = "jupyter_rospkg/_version.py" },
+    { src = "package.json" },
+]
+
+[tool.tbump.version]
+current = "0.1.2"
+regex = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)((?P<channel>a|b|rc|.dev)(?P<release>\\d+))?"
+
+[tool.tbump.git]
+message_template = "Bump to {new_version}"
+tag_template = "v{new_version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,37 @@ npm = ["jlpm"]
 
 [tool.check-manifest]
 ignore = ["jupyterlab_urdf/labextension/**", "yarn.lock", ".*", "package-lock.json"]
+
+[project]
+name = "jupyterlab-urdf"
+version = "0.1.2"
+description = "A URDF viewer and editor extension for JupyterLab"
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.7"
+authors = [
+    { name = "Isabel Paredes", email = "isabel.paredes@quantstack.net" },
+]
+keywords = ["Jupyter", "JupyterLab", "JupyterLab3"]
+classifiers = [
+    "Framework :: Jupyter",
+    "Framework :: Jupyter :: JupyterLab",
+    "Framework :: Jupyter :: JupyterLab :: 3",
+    "Framework :: Jupyter :: JupyterLab :: Extensions",
+    "Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+]
+
+[project.optional-dependencies]
+docs = [
+    "jupyterlite-sphinx",
+    "myst-parser",
+    "sphinx",
+    "sphinx-rtd-theme"
+]


### PR DESCRIPTION
This makes it easier to build the docs by installing the dependencies with
```sh
pip install -e ".[docs]"
```