### PR TITLE
Add jupyter-rospkg dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 """
 jupyterlab_urdf setup
 """
+from gettext import install
 import json
 import sys
 from pathlib import Path
@@ -51,6 +52,15 @@ setup_args = dict(
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=setuptools.find_packages(),
+    install_requires = [
+        'jupyter_rospkg',
+    ],
+    extras_require = {
+        'dev': [
+            'click',
+            'jupyter_releaser>=0.22'
+        ]
+    },
     zip_safe=False,
     include_package_data=True,
     python_requires=">=3.7",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 """
 jupyterlab_urdf setup
 """
-from gettext import install
 import json
 import sys
 from pathlib import Path

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup_args = dict(
     long_description_content_type="text/markdown",
     packages=setuptools.find_packages(),
     install_requires = [
-        'jupyter_rospkg',
+        'jupyter_rospkg>=0.3',
     ],
     extras_require = {
         'dev': [


### PR DESCRIPTION
Instead of depending on `jupyterlab-ros` to find mesh files in robot description packages, this will be replaced with `jupyter-rospkg` which accomplishes the same without the additional functionality.