### PR TITLE
Update documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,25 @@
+# Building Jupyter-ROS Documentation
+
+1. Clone the repository and create a new environment for development
+
+1. From the root directory, install the extension in editable mode
+
+   ```sh
+   pip install -e .[docs]
+   ```
+
+1. Build the documents
+
+   ```sh
+   cd jupyter-ros/docs/
+   make html
+   ```
+
+1. Open the documentation locally
+
+   ```sh
+   cd _build/html/
+   python -m http.server
+   ```
+
+1. From a web browser, navigate to `localhost:8000`

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -4,7 +4,7 @@ Without any configuration, the basic robot example can be displayed in the viewe
 
 ![Basic Robot](_static/exBasic.png)
 
-To display the basic Niryo and the Burger robot, a ROS environment needs to be configured accordingly in order for the viewer to locate the necessary mesh files, see [Tutorial for Configuring ROS Environment](http://wiki.ros.org/ROS/Tutorials/InstallingandConfiguringROSEnvironment). 
+To display the basic Niryo and the Burger robot, a ROS environment needs to be configured accordingly in order for the viewer to locate the necessary mesh files, see [Tutorial for Configuring ROS Environment](http://wiki.ros.org/ROS/Tutorials/InstallingandConfiguringROSEnvironment).
 
 The following packages are required:
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -4,9 +4,10 @@ Without any configuration, the basic robot example can be displayed in the viewe
 
 ![Basic Robot](_static/exBasic.png)
 
-To display the basic Niryo and the Burger robot, a ROS environment needs to be configured accordingly in order for the viewer to locate the necessary mesh files. The following packages are required:
+To display the basic Niryo and the Burger robot, a ROS environment needs to be configured accordingly in order for the viewer to locate the necessary mesh files, see [Tutorial for Configuring ROS Environment](http://wiki.ros.org/ROS/Tutorials/InstallingandConfiguringROSEnvironment). 
 
-- `jupyterlab-ros`
+The following packages are required:
+
 - `ros-noetic-urdf-tutorial`
 - `ros-noetic-turtlebot3-description`
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,7 +6,6 @@
 
 For running the examples and interfacing with ROS, the following packages are also required:
 
-- `jupyterlab-ros`
 - `ros-noetic-urdf-tutorial`
 - `ros-noetic-turtlebot3-description`
 

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,12 @@ setup_args = dict(
         'dev': [
             'click',
             'jupyter_releaser>=0.22'
+        ],
+        'docs': [
+            'jupyterlite-sphinx',
+            'myst-parser',
+            'sphinx',
+            'sphinx-rtd-theme'
         ]
     },
     zip_safe=False,


### PR DESCRIPTION
Remove the `jupyterlab-ros` requirement from the instructions to run the examples since this package has been replaced by `jupyter-rospkg` which is installed as a dependency. Additionally, adds list of dependencies required for building the documentation.