### PR TITLE
Automated Changelog Entry for 0.2.0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.2.0
+
+([Full Changelog](https://github.com/ihuicatl/jupyterlab-urdf/compare/v0.1.2...1c83122721711101f1973080b98eb7a359aebb6d))
+
+### Enhancements made
+
+- Add jupyter-rospkg dependency [#23](https://github.com/ihuicatl/jupyterlab-urdf/pull/23) ([@ihuicatl](https://github.com/ihuicatl))
+
+### Documentation improvements
+
+- Update documentation [#24](https://github.com/ihuicatl/jupyterlab-urdf/pull/24) ([@ihuicatl](https://github.com/ihuicatl))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/ihuicatl/jupyterlab-urdf/graphs/contributors?from=2022-07-29&to=2022-09-22&type=c))
+
+[@github-actions](https://github.com/search?q=repo%3Aihuicatl%2Fjupyterlab-urdf+involves%3Agithub-actions+updated%3A2022-07-29..2022-09-22&type=Issues) | [@ihuicatl](https://github.com/search?q=repo%3Aihuicatl%2Fjupyterlab-urdf+involves%3Aihuicatl+updated%3A2022-07-29..2022-09-22&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.2
 
 ([Full Changelog](https://github.com/ihuicatl/jupyterlab-urdf/compare/v0.1.1...36b5a10537e1d507d69decc6e39b80b4a20b88e1))
@@ -15,8 +35,6 @@
 ([GitHub contributors page for this release](https://github.com/ihuicatl/jupyterlab-urdf/graphs/contributors?from=2022-07-20&to=2022-07-29&type=c))
 
 [@github-actions](https://github.com/search?q=repo%3Aihuicatl%2Fjupyterlab-urdf+involves%3Agithub-actions+updated%3A2022-07-20..2022-07-29&type=Issues) | [@ihuicatl](https://github.com/search?q=repo%3Aihuicatl%2Fjupyterlab-urdf+involves%3Aihuicatl+updated%3A2022-07-20..2022-07-29&type=Issues) | [@vkmb](https://github.com/search?q=repo%3Aihuicatl%2Fjupyterlab-urdf+involves%3Avkmb+updated%3A2022-07-20..2022-07-29&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.1.1
 


### PR DESCRIPTION
Automated Changelog Entry for 0.2.0 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/ihuicatl/jupyterlab-urdf/releases/tag/untagged-81606d34f287b04e1ccb  |
| Since | v0.1.2 |